### PR TITLE
Updating samples yamls to accomodate clusternetworkprofile changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ The ClusterProfile API also allows to specify all the configurable details with 
 
 The complete API spec for the ClusterProfile can be found here: [CRD](docs/control-cluster/api_docs.md#clusterprofile)
 
-An example of the ClusterProfile CR can be found here: [Example CR](config/samples/aci-cni/kubernetes/clusterprofile_aci.yaml)
+An example of the ClusterProfile CR can be found here: [Example CR](config/samples/aci-cni/kubernetes/clusterGroupProfile/clusterprofile_k8s.yaml)
 
 Once the ClusterProfile CR is created successfully, the focus shifts to the Workload Cluster to deploy CKO operator by following these [instructions](#32-workload-cluster). This will result in CKO running in the Workload Cluster and which will in turn deploy the CNI.
 
@@ -616,15 +616,15 @@ Also updates to properties such as CNI management modes (managed versus unmanage
 
 The complete API spec for the ClusterGroupProfile can be found here: [CRD](docs/control-cluster/api_docs.md#clustergroupprofile)
 
-An example of the ClusterGroupProfile CR can be found here: [Example CR](config/samples/aci-cni/kubernetes/clustergroupprofile_aci.yaml)
+An example of the ClusterGroupProfile CR can be found here: [Example CR](config/samples/aci-cni/kubernetes/clusterGroupProfile/clustergroupprofile_k8s.yaml)
 
 #### 4.1.5 Managing Clusters Individually
 
-Create ClusterNetworkProfile ConfigMap with all the specific desired properties for this cluster.
+Create ClusterNetworkProfile CR with all the specific desired properties for this cluster.
 
 Create ClusterProfile for cluster, set ClusterNetworkProfileSelector to match ClusterNetworkProfile's labels.
 
-An example of the ClusterNetworkProfile ConfigMap can be found here: [Example CR](config/samples/aci-cni/kubernetes/config_maps.yaml)
+An example of the ClusterNetworkProfile CR can be found here: [Example CR](config/samples/aci-cni/kubernetes/clusterNetworkProfile/clusternetworkprofile.yaml)
 
 #### 4.1.6 Customizing Default Behaviors
 * ConfigMap for ClusterProfle global default settings: defaults-cluster-profile.yaml

--- a/config/samples/aci-cni/kubernetes/ClusterNetworkProfile/clusternetworkprofile.yaml
+++ b/config/samples/aci-cni/kubernetes/ClusterNetworkProfile/clusternetworkprofile.yaml
@@ -1,16 +1,15 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: netop.mgr/v1alpha1
+kind: ClusterNetworkProfile
 metadata:
-  name: ocp-dev-001
+  name: ocp-dev-002
   namespace: netop-manager
   labels:
     cni: aci
-    distro: openshift
+    distro: kubernetes
     environment: dev
-    netProfile: ocp-dev-001
+    netProfile: ocp-dev-002
     platform: esx
-data:
- clusternetworkprofile_overrides: |
+spec:
   config_overrides:                                        # this section supports all overrides that are possible to do in the clusterProfile or clusterGroupProfile
     aci_cni_config:                                        
       aci_config:                                          # aci_config section consists of ACI related configuration - Tenant, VRF, L3out, BGP, AEP.
@@ -18,33 +17,25 @@ data:
         vmm_domain:                                        # Kubernetes container domain configuration
           encap_type: vxlan                                # Encap mode: vxlan or vlan
           mcast_range:                                     # Every opflex VMM must use a distinct range
-              start: 225.114.1.1
-              end: 225.114.255.255
+              start: 225.115.1.1
+              end: 225.115.255.255
           nested_inside:                                   # Include if nested inside a VMM (esxi only)
             type: vmware                                   # Specify the VMM vendor (supported: vmware)
             name: prod-dvs-01                              # Specify the name of the VMM domain
-            installer_provisioned_lb_ip: 192.168.57.2      # Mandatory field for Openshift on ESX flavor. Points to the Loadbalancer in front of kube API and Ingress Router (which later can be changed to ACI-CNI load-balancer)
+            installer_provisioned_lb_ip: 192.168.58.2      # Mandatory field for Openshift on ESX flavor. Points to the Loadbalancer in front of kube API and Ingress Router (which later can be changed to ACI-CNI load-balancer)
       logging:
         controller_log_level: debug
         hostagent_log_level: debug
         opflexagent_log_level: debug
       net_config:                                          # this is specific to aci-cni only 
-        extern_static: 10.4.0.1/24                         # Subnet to use for static external IPs
-        service_vlan: 292                                  # The VLAN used by service graph for LoadBalancer service type
-        node_svc_subnet: 10.5.0.1/24                       # Subnet used by service graph for LoadBalancer service type
+        extern_static: 10.10.0.1/24                         # Subnet to use for static external IPs
+        service_vlan: 298                                   # The VLAN used by service graph for LoadBalancer service type
+        node_svc_subnet: 10.11.0.1/24                       # Subnet used by service graph for LoadBalancer service type
       kube_config:
         opflex_agent_prometheus: false
         ovs_memory_limit: 1Gi
         image_pull_policy: Always
-      l3out:                                               # L3out for external access must exists before applying clusterProfile in CKO.
-        name: dev-001-l3out                                # name of L3out that will provide access to the openshift cluster.
-        external_networks:
-        - internet                                         # name of the external EPG under L3out that will provide contract for external access.
-      vrf:
-        name: dev-001-vrf                                  # vrf name where openshift BD's will be deployed.
-        tenant: common                                     # tenant name where openshift BD's will be deployed. It will be used as System-ID.
-      registry:                                            # registry path for ACI-CNI images with custom tags   
-        image_prefix: quay.io/noirolabs
+      registry: # registry path for ACI-CNI images with custom tags
         aci_containers_controller_version: 5.2.3.6.1d150da
         acc_provision_operator_version: 5.2.3.6.1d150da
         aci_containers_host_version: 5.2.3.6.1d150da
@@ -52,22 +43,29 @@ data:
         cnideploy_version: 5.2.3.6.1d150da
         opflex_agent_version: 5.2.3.6.1d150da
         openvswitch_version: 5.2.3.6.1d150da
+    aci_config:
+      l3out:                                               # L3out for external access must exists before applying clusterProfile in CKO.
+        name: dev-001-l3out                                # name of L3out that will provide access to the openshift cluster.
+        external_networks:
+        - internet                                         # name of the external EPG under L3out that will provide contract for external access.
+      vrf:
+        name: dev-001-vrf                                  # vrf name where openshift BD's will be deployed.
+        tenant: common                                     # tenant name where openshift BD's will be deployed. It will be used as System-ID.
     registry:                                              # registry path for netop-manager operator that will be installed in workload cluster
       image_prefix: quay.io/cko 
       network_operator_version: 0.9.1.d04f56f
     net_config:                                            # rest of the openshift subnets configuration. This section is common for Calico and ACI CNI.
-      node_subnet: 192.168.57.1/24                         # Subnet to use for nodes       
+      node_subnet: 192.168.58.1/24                         # Subnet to use for nodes       
       pod_subnet: 10.2.0.1/16                              # Subnet to use for Kubernetes Pods
-      extern_dynamic: 10.3.0.1/24                          # Subnet to use for dynamic external IPs
-      kubeapi_vlan: 291                                    # The VLAN used by the node network (in case of baremetal deployment)
+      extern_dynamic: 10.9.0.1/24                          # Subnet to use for dynamic external IPs
+      kubeapi_vlan: 299                                    # The VLAN used by the node network (in case of baremetal deployment)
     cni: aci                                               # CNI type - for ACI-CNI: "aci", for Calico: "calico"
     operator_config:
       target_version: 0.9.1                                # netop-manager operator version that will be running on workload cluster.
     distro:
-      type: openshift                                      # required field to specify exact flavor of the openshift distribution.
-      release: "4.10"                                      # required field to specify exact flavor of the openshift distribution.
+      type: kubernetes                                     # required field to specify exact flavor of the openshift distribution.
+      release: "1.24"                                      # required field to specify exact flavor of the openshift distribution.
       platform: esx                                        # required field to specify exact flavor of the openshift distribution.
-      flavor: "openshift-4.10-esx"                         # optional field that will be computed from distro.type, distro.release, distro.platform.
     cko_proxy_config:                                      # optional proxy configuration for netop-manager operator to access git repo.
       http_proxy: http://proxy.myorg.com:80
       https_proxy: http://proxy.myorg.com:80

--- a/config/samples/aci-cni/kubernetes/imported/auto-clusternetworkprofile.yaml
+++ b/config/samples/aci-cni/kubernetes/imported/auto-clusternetworkprofile.yaml
@@ -1,7 +1,74 @@
-apiVersion: v1
-data:
-  clusternetworkprofile_overrides: '{"config_overrides":{"aci_config":{"system_id":"bm2acicni","l3out":{"name":"sauto_l3out-1","external_networks":["sauto_l3out-1_epg"]},"cluster_l3out":{"svi":{},"bgp":{"peering":{}}},"vrf":{"name":"sauto_l3out-1_vrf","tenant":"common"},"physical_domain":{}},"aci_cni_config":{"aci_config":{"vmm_domain":{"mcast_range":{},"nested_inside":{}},"aep":"bm-srvrs-aep"},"net_config":{"extern_static":"10.4.0.1/16","service_vlan":102,"node_svc_subnet":"10.5.0.1/16"},"registry":{"acc_provision_operator_version":"kmr2-test","aci_containers_operator_version":"kmr2-test","aci_containers_controller_version":"kmr2-test","aci_containers_host_version":"kmr2-test","cnideploy_version":"kmr2-test","opflex_agent_version":"kmr2-test","openvswitch_version":"kmr2-test"},"kube_config":{"image_pull_policy":"Always","operator_managed_config":{},"ovs_memory_limit":"0.75Gi","istio_config":{},"drop_log_config":{},"multus":{},"sriov_config":{},"nodepodif_config":{}},"logging":{"controller_log_level":"debug","hostagent_log_level":"debug","opflexagent_log_level":"debug"}},"net_config":{},"registry":{},"calico_cni_config":{},"profile":{},"service_mesh_config":{},"cko_git_config":{},"monitoring_config":{},"lb_config":{},"cko_proxy_config":{},"topology":{},"context":{"vrf":{},"l3out":{}},"distro":{},"operator_config":{},"connectivity_checker":{"reachability_test_enable":{"periodic_sync":{},"external_url":{}}},"fabricinfra":{"name":"k8s-bm-2","type":"aci"}}}'
-kind: ConfigMap
+apiVersion: netop.mgr/v1alpha1
+kind: ClusterNetworkProfile
+spec:
+  config_overrides:
+    aci_config:
+      system_id: bm2acicni
+      l3out:
+        name: sauto_l3out-1
+        external_networks:
+          - sauto_l3out-1_epg
+      cluster_l3out:
+        svi: {}
+        bgp:
+          peering: {}
+      vrf:
+        name: sauto_l3out-1_vrf
+        tenant: common
+      physical_domain: {}
+    aci_cni_config:
+      aci_config:
+        vmm_domain:
+          mcast_range: {}
+          nested_inside: {}
+        aep: bm-srvrs-aep
+      net_config:
+        extern_static: 10.4.0.1/16
+        service_vlan: 102
+        node_svc_subnet: 10.5.0.1/16
+      registry:
+        acc_provision_operator_version: kmr2-test
+        aci_containers_operator_version: kmr2-test
+        aci_containers_controller_version: kmr2-test
+        aci_containers_host_version: kmr2-test
+        cnideploy_version: kmr2-test
+        opflex_agent_version: kmr2-test
+        openvswitch_version: kmr2-test
+      kube_config:
+        image_pull_policy: Always
+        operator_managed_config: {}
+        ovs_memory_limit: 0.75Gi
+        istio_config: {}
+        drop_log_config: {}
+        multus: {}
+        sriov_config: {}
+        nodepodif_config: {}
+      logging:
+        controller_log_level: debug
+        hostagent_log_level: debug
+        opflexagent_log_level: debug
+    net_config: {}
+    registry: {}
+    calico_cni_config: {}
+    profile: {}
+    service_mesh_config: {}
+    cko_git_config: {}
+    monitoring_config: {}
+    lb_config: {}
+    cko_proxy_config: {}
+    topology: {}
+    context:
+      vrf: {}
+      l3out: {}
+    distro: {}
+    operator_config: {}
+    connectivity_checker:
+      reachability_test_enable:
+        periodic_sync: {}
+        external_url: {}
+    fabricinfra:
+      name: k8s-bm-2
+      type: aci
 metadata:
   annotations:
     notification-controller.netop.mgr/created: "true"

--- a/config/samples/aci-cni/openshift/clusterNetworkProfile/clusternetworkprofile.yaml
+++ b/config/samples/aci-cni/openshift/clusterNetworkProfile/clusternetworkprofile.yaml
@@ -1,16 +1,15 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: netop.mgr/v1alpha1
+kind: ClusterNetworkProfile
 metadata:
-  name: ocp-dev-002
+  name: ocp-dev-001
   namespace: netop-manager
   labels:
     cni: aci
-    distro: kubernetes
+    distro: openshift
     environment: dev
-    netProfile: ocp-dev-002
+    netProfile: ocp-dev-001
     platform: esx
-data:
- clusternetworkprofile_overrides: |
+spec:
   config_overrides:                                        # this section supports all overrides that are possible to do in the clusterProfile or clusterGroupProfile
     aci_cni_config:                                        
       aci_config:                                          # aci_config section consists of ACI related configuration - Tenant, VRF, L3out, BGP, AEP.
@@ -18,33 +17,25 @@ data:
         vmm_domain:                                        # Kubernetes container domain configuration
           encap_type: vxlan                                # Encap mode: vxlan or vlan
           mcast_range:                                     # Every opflex VMM must use a distinct range
-              start: 225.115.1.1
-              end: 225.115.255.255
+              start: 225.114.1.1
+              end: 225.114.255.255
           nested_inside:                                   # Include if nested inside a VMM (esxi only)
             type: vmware                                   # Specify the VMM vendor (supported: vmware)
             name: prod-dvs-01                              # Specify the name of the VMM domain
-            installer_provisioned_lb_ip: 192.168.58.2      # Mandatory field for Openshift on ESX flavor. Points to the Loadbalancer in front of kube API and Ingress Router (which later can be changed to ACI-CNI load-balancer)
+            installer_provisioned_lb_ip: 192.168.57.2      # Mandatory field for Openshift on ESX flavor. Points to the Loadbalancer in front of kube API and Ingress Router (which later can be changed to ACI-CNI load-balancer)
       logging:
         controller_log_level: debug
         hostagent_log_level: debug
         opflexagent_log_level: debug
       net_config:                                          # this is specific to aci-cni only 
-        extern_static: 10.10.0.1/24                         # Subnet to use for static external IPs
-        service_vlan: 298                                   # The VLAN used by service graph for LoadBalancer service type
-        node_svc_subnet: 10.11.0.1/24                       # Subnet used by service graph for LoadBalancer service type
+        extern_static: 10.4.0.1/24                         # Subnet to use for static external IPs
+        service_vlan: 292                                  # The VLAN used by service graph for LoadBalancer service type
+        node_svc_subnet: 10.5.0.1/24                       # Subnet used by service graph for LoadBalancer service type
       kube_config:
         opflex_agent_prometheus: false
         ovs_memory_limit: 1Gi
-        image_pull_policy: Always
-      l3out:                                               # L3out for external access must exists before applying clusterProfile in CKO.
-        name: dev-001-l3out                                # name of L3out that will provide access to the openshift cluster.
-        external_networks:
-        - internet                                         # name of the external EPG under L3out that will provide contract for external access.
-      vrf:
-        name: dev-001-vrf                                  # vrf name where openshift BD's will be deployed.
-        tenant: common                                     # tenant name where openshift BD's will be deployed. It will be used as System-ID.
-      registry:                                            # registry path for ACI-CNI images with custom tags   
-        image_prefix: quay.io/noirolabs
+        image_pull_policy: Always                                  # tenant name where openshift BD's will be deployed. It will be used as System-ID.
+      registry:                                            # registry path for ACI-CNI images with custom tags
         aci_containers_controller_version: 5.2.3.6.1d150da
         acc_provision_operator_version: 5.2.3.6.1d150da
         aci_containers_host_version: 5.2.3.6.1d150da
@@ -52,21 +43,30 @@ data:
         cnideploy_version: 5.2.3.6.1d150da
         opflex_agent_version: 5.2.3.6.1d150da
         openvswitch_version: 5.2.3.6.1d150da
+    aci_config:
+      l3out: # L3out for external access must exists before applying clusterProfile in CKO.
+        name: dev-001-l3out                                # name of L3out that will provide access to the openshift cluster.
+        external_networks:
+          - internet                                         # name of the external EPG under L3out that will provide contract for external access.
+      vrf:
+        name: dev-001-vrf                                  # vrf name where openshift BD's will be deployed.
+        tenant: common
     registry:                                              # registry path for netop-manager operator that will be installed in workload cluster
       image_prefix: quay.io/cko 
       network_operator_version: 0.9.1.d04f56f
     net_config:                                            # rest of the openshift subnets configuration. This section is common for Calico and ACI CNI.
-      node_subnet: 192.168.58.1/24                         # Subnet to use for nodes       
+      node_subnet: 192.168.57.1/24                         # Subnet to use for nodes       
       pod_subnet: 10.2.0.1/16                              # Subnet to use for Kubernetes Pods
-      extern_dynamic: 10.9.0.1/24                          # Subnet to use for dynamic external IPs
-      kubeapi_vlan: 299                                    # The VLAN used by the node network (in case of baremetal deployment)
+      extern_dynamic: 10.3.0.1/24                          # Subnet to use for dynamic external IPs
+      kubeapi_vlan: 291                                    # The VLAN used by the node network (in case of baremetal deployment)
     cni: aci                                               # CNI type - for ACI-CNI: "aci", for Calico: "calico"
     operator_config:
       target_version: 0.9.1                                # netop-manager operator version that will be running on workload cluster.
     distro:
-      type: kubernetes                                     # required field to specify exact flavor of the openshift distribution.
-      release: "1.24"                                      # required field to specify exact flavor of the openshift distribution.
+      type: openshift                                      # required field to specify exact flavor of the openshift distribution.
+      release: "4.10"                                      # required field to specify exact flavor of the openshift distribution.
       platform: esx                                        # required field to specify exact flavor of the openshift distribution.
+      flavor: "openshift-4.10-esx"                         # optional field that will be computed from distro.type, distro.release, distro.platform.
     cko_proxy_config:                                      # optional proxy configuration for netop-manager operator to access git repo.
       http_proxy: http://proxy.myorg.com:80
       https_proxy: http://proxy.myorg.com:80

--- a/config/samples/calico/clusterNetworkProfile/clusternetworkprofile.yaml
+++ b/config/samples/calico/clusterNetworkProfile/clusternetworkprofile.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: netop.mgr/v1alpha1
+kind: ClusterNetworkProfile
 metadata:
   name: k8s-dev-001                                     # because config map for NetworkProfile is defined per k8s/ocp cluster it can have the same name as clusterProfile.
   namespace: netop-manager
@@ -9,8 +9,7 @@ metadata:
     environment: dev                                    
     netProfile: k8s-dev-001
     platform: baremetal    
-data:
- clusternetworkprofile_overrides: |
+spec:
   config_overrides:                                      # this section supports all overrides that are possible to do in the clusterProfile or clusterGroupProfile
     registry:                    
       image_prefix: quay.io/cko


### PR DESCRIPTION
1. The ConfigMap used for clusternetworkProfile have been transitioned to CustomResource. Thus to accomodate these changes, the yamls with configmap kind are changed to ClusterNetworkProfile Custom Resources

2. The REAMDE document having corresponding links to sample configs to show correct yamls. Also , configMap for clusternetworkprofile is renamed to CR (Custom Resource)